### PR TITLE
Removed dataframes as input to model_index

### DIFF
--- a/notebooks/Example_Data_Downloading.ipynb
+++ b/notebooks/Example_Data_Downloading.ipynb
@@ -57,10 +57,13 @@
    "outputs": [],
    "source": [
     "# Import model index functions\n",
-    "from model_index import ModelIndex\n",
+    "from pyprediktormapclient.model_index import ModelIndex\n",
     "\n",
     "# Import OPC UA functions\n",
-    "from opc_ua import OPC_UA"
+    "from pyprediktormapclient.opc_ua import OPC_UA\n",
+    "\n",
+    "# Import \"Dataframer\" Tools\n",
+    "from pyprediktormapclient.shared import *"
    ]
   },
   {
@@ -70,15 +73,15 @@
    "outputs": [],
    "source": [
     "# Connection to the servers\n",
-    "model_index_url = \"http://10.241.68.86:7001/v1/\"\n",
-    "opcua_rest_url = \"http://10.241.68.86:13371/\"\n",
-    "opcua_server_url = \"opc.tcp://10.241.80.4:4872\"\n",
+    "model_index_url = \"http://10.100.59.152:13371/v1/\"\n",
+    "opcua_rest_url = \"https://apis-opcua-api.pview.dev/\"\n",
+    "opcua_server_url = \"opc.tcp://81.166.54.193:4853\"\n",
     "\n",
     "# Model index API\n",
     "model = ModelIndex(url=model_index_url)\n",
     "\n",
     "# OPC UA API\n",
-    "tsdata = OPC_UA(rest_url=opcua_rest_url, opcua_url=opcua_server_url)"
+    "tsdata = OPC_UA(rest_url=opcua_rest_url, opcua_url= opcua_server_url)"
    ]
   },
   {
@@ -122,9 +125,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Selecting specific site \n",
-    "sitename = 'EG-AS'\n",
-    "site = sites[sites['Name'] == sitename]"
+    "# Selecting the first site\n",
+    "site = sites.iloc[0]\n",
+    "site_ids = [site['Id']]"
    ]
   },
   {
@@ -141,7 +144,7 @@
    "outputs": [],
    "source": [
     "# All the inverters on the site\n",
-    "inverters = model.get_object_descendants(\"InverterType\", site, \"PV_Assets\", return_format=\"dataframe\")\n",
+    "inverters = model.get_object_descendants(\"InverterType\", site_ids, \"PV_Assets\", return_format=\"dataframe\")\n",
     "inverters"
    ]
   },
@@ -211,7 +214,7 @@
    "outputs": [],
    "source": [
     "# Strings set data \n",
-    "strings = model.get_object_descendants(\"StringSetType\", site, \"PV_Assets\", return_format=\"dataframe\")\n",
+    "strings = model.get_object_descendants(\"StringSetType\", site_ids, \"PV_Assets\", return_format=\"dataframe\")\n",
     "strings"
    ]
   },
@@ -280,7 +283,7 @@
    "outputs": [],
    "source": [
     "# Trackers data \n",
-    "trackers = model.get_object_ancestors_as_dataframe(\"TrackerType\", strings, \"PV_Serves\")\n",
+    "trackers = model.get_object_ancestors(\"TrackerType\", get_ids_from_dataframe(strings), \"PV_Serves\", return_format=\"dataframe\")\n",
     "trackers"
    ]
   },

--- a/notebooks/Exploring_API_Functions.ipynb
+++ b/notebooks/Exploring_API_Functions.ipynb
@@ -156,11 +156,11 @@
    "outputs": [],
    "source": [
     "# To get the objects of a type\n",
-    "obj_of_types_json = model.get_objects_of_type(\"SiteType\", return_format=\"json\")\n",
+    "sitetypes = model.get_objects_of_type(\"SiteType\")\n",
     "\n",
     "# Send the returned JSON into a normalizer to get Id, Type, Name, Props and Vars as columns\n",
-    "obj_of_types = normalize_as_dataframe(obj_of_types_json)\n",
-    "obj_of_types"
+    "sitetypes_dataframe = normalize_as_dataframe(sitetypes)\n",
+    "sitetypes_dataframe"
    ]
   },
   {
@@ -169,8 +169,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Get the list of ids from\n",
+    "sitetype_ids = get_ids_from_dataframe(sitetypes_dataframe)\n",
     "# Descendents of an object type\n",
-    "obj_descendents = model.get_object_descendants(\"StringSetType\", obj_of_types, \"PV_Assets\", return_format=\"dataframe\")\n",
+    "obj_descendents = model.get_object_descendants(\"StringSetType\", sitetype_ids, \"PV_Assets\", return_format=\"dataframe\")\n",
     "obj_descendents"
    ]
   },
@@ -182,11 +184,10 @@
    "source": [
     "# All the sites on the OPC server\n",
     "sites = model.get_objects_of_type('SiteType', return_format=\"dataframe\")\n",
-    "\n",
-    "# Selecting specific site \n",
-    "sitename = 'JO-GL'\n",
-    "site = sites[sites['Name'] == sitename]\n",
-    "sites"
+    "sites\n",
+    "# Selecting the first site\n",
+    "site = sites.iloc[0]\n",
+    "site_ids = [site['Id']]"
    ]
   },
   {
@@ -195,8 +196,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Object descendants data of a specific site BR-AP\n",
-    "strings = model.get_object_descendants(\"StringSetType\", site, \"PV_Assets\", return_format=\"dataframe\")\n",
+    "# Object descendants data of a specific site for that park\n",
+    "strings = model.get_object_descendants(\"StringSetType\", site_ids, \"PV_Assets\", return_format=\"dataframe\")\n",
     "strings"
    ]
   },
@@ -207,7 +208,7 @@
    "outputs": [],
    "source": [
     "# Ancestors of an object type\n",
-    "obj_ancestors = model.get_object_ancestors(\"TrackerType\", strings, \"PV_Serves\", return_format=\"dataframe\")\n",
+    "obj_ancestors = model.get_object_ancestors(\"TrackerType\", get_ids_from_dataframe(strings), \"PV_Serves\", return_format=\"dataframe\")\n",
     "obj_ancestors "
    ]
   },

--- a/src/pyprediktormapclient/model_index.py
+++ b/src/pyprediktormapclient/model_index.py
@@ -16,24 +16,13 @@ class ModelIndex:
         self.url = url
         self.object_types = self.get_object_types(return_format="json")
 
-    def as_dataframe(self, content) -> pd.DataFrame:
-        """Function to convert a json string to Pandas DataFrame
-
-        Args:
-            content (str): the json string
-        """
-        if content is None:
-            return None
-
-        return pd.DataFrame(content)
-
-    def get_namespace_array(self, return_format="dataframe") -> str:
+    def get_namespace_array(self, return_format="json") -> str:
         content = request_from_api(self.url, "GET", "query/namespace-array")
         if return_format == "dataframe":
             return normalize_as_dataframe(content)
         return content
 
-    def get_object_types(self, return_format="dataframe") -> str:
+    def get_object_types(self, return_format="json") -> str:
         content = request_from_api(self.url, "GET", "query/object-types")
         if return_format == "dataframe":
             return normalize_as_dataframe(content)
@@ -59,26 +48,7 @@ class ModelIndex:
 
         return object_type_id
 
-    def get_object_ids_from_dataframe(self, obj_dataframe: pd.DataFrame) -> list:
-        """Extracts data from one of the three columns in the supplied
-        Pandas DataFrame as list: "Id", "DescendantId", "AncestorId".
-
-        Args:
-            obj_dataframe (pd.DataFrame): DataFrame with a column called "Id", "DescendantId" or "AncestorId"
-
-        Returns:
-            list: a list with ids (empty if None)
-        """
-        try:
-            id_column = [
-                x for x in obj_dataframe if x in ["Id", "DescendantId", "AncestorId"]
-            ][0]
-        except IndexError:
-            return []
-
-        return obj_dataframe[id_column].to_list()
-
-    def get_objects_of_type(self, type_name: str, return_format="dataframe") -> str:
+    def get_objects_of_type(self, type_name: str, return_format="json") -> str:
         """Function to get all the types of an object
 
         Args:
@@ -101,15 +71,15 @@ class ModelIndex:
     def get_object_descendants(
         self,
         type_name: str,
-        obj_dataframe: pd.DataFrame,
+        ids: list,
         domain: str,
-        return_format="dataframe",
+        return_format="json",
     ) -> str:
         """A function to get object descendants
 
         Args:
             type_name (str): type_name of a descendant
-            obj_dataframe (pd.DataFrame): dataframe of object ids
+            ids (list): a list of ids you want the descendants for
             domain (str): PV_Assets or PV_Serves
 
         Returns:
@@ -122,7 +92,7 @@ class ModelIndex:
         body = json.dumps(
             {
                 "typeId": id,
-                "objectIds": self.get_object_ids_from_dataframe(obj_dataframe),
+                "objectIds": ids,
                 "domain": domain,
             }
         )
@@ -135,15 +105,15 @@ class ModelIndex:
     def get_object_ancestors(
         self,
         type_name: str,
-        obj_dataframe: pd.DataFrame,
+        ids: list,
         domain: str,
-        return_format="dataframe",
+        return_format="json",
     ) -> str:
         """Function to get object ancestors
 
         Args:
-            type_name (str): type_name of a parent type
-            obj_dataframe (pd.DataFrame): dataframe of object ids
+            type_name (str): the ancestor parent type
+            ids (list): a list of ids you want the ancestors for
             domain (str): Either PV_Assets or PV_Serves
 
         Returns:
@@ -156,7 +126,7 @@ class ModelIndex:
         body = json.dumps(
             {
                 "typeId": id,
-                "objectIds": self.get_object_ids_from_dataframe(obj_dataframe),
+                "objectIds": ids,
                 "domain": domain,
             }
         )

--- a/src/pyprediktormapclient/shared.py
+++ b/src/pyprediktormapclient/shared.py
@@ -86,3 +86,18 @@ def normalize_as_dataframe(content: str):
         )
 
     return df
+
+def get_ids_from_dataframe(obj_dataframe: pd.DataFrame) -> list:
+    """Extracts data from "Id" column in a DataFrame or an empty list if none.
+
+    Args:
+        obj_dataframe (pd.DataFrame): DataFrame with a column called "Id"
+
+    Returns:
+        list: a list with ids (empty if None)
+    """
+
+    if "Id" in obj_dataframe.columns:
+        return obj_dataframe["Id"].to_list()
+    
+    return []

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -1,8 +1,9 @@
 import unittest
 from unittest import mock
 from pandas.testing import assert_frame_equal
+import pandas as pd
 
-from pyprediktormapclient.shared import normalize_as_dataframe
+from pyprediktormapclient.shared import normalize_as_dataframe, get_ids_from_dataframe
 
 objects_of_type = [
     {
@@ -20,12 +21,32 @@ objects_of_type = [
     }
 ]
 
+correct_df = pd.DataFrame({
+    "Id": ["1","2"],
+    "AnotherColumnName":  [40,34]
+})
+
+incorrect_df = pd.DataFrame({
+    "FirstColumnName": ["1","2"],
+    "AnotherColumnName":  [40,34]
+})
+
+
 # Our test case class
 class SharedTestCase(unittest.TestCase):
     def test_get_object_types_as_json(self):
         result = normalize_as_dataframe(objects_of_type)
         assert "DisplayName" not in result.columns
         assert "Name" in result.columns
+        
+    def test_get_ids_from_dataframe_success(self):
+        result = get_ids_from_dataframe(correct_df)
+        assert result == ["1", "2"]
+
+    def test_get_ids_from_dataframe_failure(self):
+        result = get_ids_from_dataframe(incorrect_df)
+        assert result != ["1", "2"]
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
To fit more as a proper model_index library, inputs that was DataFrames are now lists, and functions to get lists of ids from a data frame is moved to shared. Tests included for the shared functionality