### PR TITLE
Change HttpUrl to allow for calling rest url's where we dont have TLD

### DIFF
--- a/src/pyprediktormapclient/auth_client.py
+++ b/src/pyprediktormapclient/auth_client.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, HttpUrl, validate_call, AwareDatetime, field_validator
+from pydantic import BaseModel, AnyUrl, validate_call, AwareDatetime, field_validator
 from pyprediktormapclient.shared import request_from_api
 import datetime
 import json
@@ -35,7 +35,7 @@ class AUTH_CLIENT:
 
     """
     @validate_call
-    def __init__(self, rest_url: HttpUrl, username: str, password: str):
+    def __init__(self, rest_url: AnyUrl, username: str, password: str):
         """Class initializer
 
         Args:

--- a/src/pyprediktormapclient/model_index.py
+++ b/src/pyprediktormapclient/model_index.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from typing import List
-from pydantic import HttpUrl, validate_call
+from pydantic import AnyUrl, validate_call
 from pyprediktormapclient.shared import request_from_api
 
 logger = logging.getLogger(__name__)
@@ -19,7 +19,7 @@ class ModelIndex:
     """
 
     @validate_call
-    def __init__(self, url: HttpUrl):
+    def __init__(self, url: AnyUrl):
         self.url = url
         self.object_types = self.get_object_types()
 

--- a/src/pyprediktormapclient/opc_ua.py
+++ b/src/pyprediktormapclient/opc_ua.py
@@ -6,7 +6,7 @@ import copy
 import pandas as pd
 from datetime import date, datetime, timedelta
 from typing import Dict, List, Union, Optional
-from pydantic import BaseModel, HttpUrl, AnyUrl, validate_call
+from pydantic import BaseModel, AnyUrl, validate_call
 from pydantic_core import Url
 from pyprediktormapclient.shared import request_from_api
 from requests import HTTPError
@@ -152,7 +152,7 @@ class OPC_UA:
 
 
     @validate_call
-    def __init__(self, rest_url: HttpUrl, opcua_url: AnyUrl, namespaces: List = None, auth_client: object = None):
+    def __init__(self, rest_url: AnyUrl, opcua_url: AnyUrl, namespaces: List = None, auth_client: object = None):
         """Class initializer
 
         Args:

--- a/src/pyprediktormapclient/shared.py
+++ b/src/pyprediktormapclient/shared.py
@@ -1,11 +1,11 @@
 import requests
-from pydantic import HttpUrl, validate_call
+from pydantic import AnyUrl, validate_call
 from typing import Literal
 
 
 @validate_call
 def request_from_api(
-    rest_url: HttpUrl,
+    rest_url: AnyUrl,
     method: Literal["GET", "POST"],
     endpoint: str,
     data: str = None,


### PR DESCRIPTION
We have scenarios where the url's for model index api & opc ua rest values api does not contain the Top level domain. This pull request changes Pydantic HttpUrl to AnyUrl in all files where its needed.

From pydantic;
[AnyUrl](https://docs.pydantic.dev/latest/api/networks/#pydantic.networks.AnyUrl): any scheme allowed, top-level domain (TLD) not required, host required.


[HttpUrl](https://docs.pydantic.dev/latest/api/networks/#pydantic.networks.HttpUrl): scheme http or https, TLD required, host required, max length 2083.