### PR TITLE
Update version scheme and setup configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 # For smarter version schemes and other configuration options,
 # check out https://github.com/pypa/setuptools_scm
-version_scheme = "no-guess-dev"
+version_scheme = "post-release"
 
 [tool.pytest.ini_options]
 pythonpath = [

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup
 
 if __name__ == "__main__":
     try:
-        setup(use_scm_version={"version_scheme": "no-guess-dev"})
+        setup(use_scm_version={"version_scheme": "post-release"})
     except:  # noqa
         print(
             "\n\nAn error occurred while building the project, "


### PR DESCRIPTION
Update version scheme to 'post-release' and modify setup configuration to correctly handle versioning for both tagged and non-tagged commits.