### PR TITLE
1347 maf service support new format on solcast api fix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ install_requires =
     pydantic >= 2.0
     pandas >= 1.4.4
     pyodbc
-    pyPrediktorUtilities >= 0.3.2
+    pyPrediktorUtilities >= 0.4.1
 
 [options.packages.find]
 where = src
@@ -71,7 +71,7 @@ testing =
     setuptools
     pytest
     pytest-cov
-    pyPrediktorUtilities >= 0.3.2
+    pyPrediktorUtilities >= 0.4.1
     pyodbc
 
 [options.entry_points]

--- a/src/pyprediktormapclient/dwh/dwh.py
+++ b/src/pyprediktormapclient/dwh/dwh.py
@@ -79,7 +79,6 @@ class DWH(Db, IDWH):
     Private
     """
 
-    
     def __initialize_context_services(self) -> None:
         """
         Initialise all services defined in `context` folder. These are methods
@@ -101,4 +100,4 @@ class DWH(Db, IDWH):
                         setattr(self, service_name, attribute(self))
 
     def _is_attr_valid_service_class(self, attribute) -> bool:
-        return isinstance(attribute, type) and issubclass(attribute, IDWH) and attribute is not IDWH
+        return isinstance(attribute, type) and attribute is not IDWH


### PR DESCRIPTION
[Trello ticket](https://trello.com/c/sHjRYQkc/1347-maf-service-support-new-format-on-solcast-api)
[Monday ticket](https://prediktor-team.monday.com/boards/6331897616/pulses/6514914717)

The version of pyPrediktorUtilities has been updated to 0.4.1.

Also, we no longer need to check if the loaded context class is a subclass of IDWH.