### PR TITLE
Update pyPrediktorUtilities to v0.4.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ install_requires =
     pydantic >= 2.0, < 3.0.0
     pandas >= 1.4.4, < 3.0.0
     pyodbc < 6.0.0
-    pyPrediktorUtilities == 0.4.3
+    pyPrediktorUtilities == 0.4.4
 
 [options.packages.find]
 where = src
@@ -72,7 +72,7 @@ testing =
     pytest < 9.0.0
     pytest-cov < 6.0.0
     nest_asyncio < 2.0.0
-    pyPrediktorUtilities == 0.4.3
+    pyPrediktorUtilities == 0.4.4
     pyodbc < 6.0.0
 
 [options.entry_points]


### PR DESCRIPTION
This PR consists of:
- updating pyPrediktorUtilities to v0.4.4