### PR TITLE
PENGSOL-555-update-the-version-of-pyPrediktorUtilities

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ install_requires =
     pydantic >= 2.0, < 3.0.0
     pandas >= 1.4.4, < 3.0.0
     pyodbc < 6.0.0
-    pyPrediktorUtilities == 0.4.4
+    pyPrediktorUtilities == 0.4.5
 
 [options.packages.find]
 where = src
@@ -72,7 +72,7 @@ testing =
     pytest < 9.0.0
     pytest-cov < 6.0.0
     nest_asyncio < 2.0.0
-    pyPrediktorUtilities == 0.4.4
+    pyPrediktorUtilities == 0.4.5
     pyodbc < 6.0.0
 
 [options.entry_points]


### PR DESCRIPTION
[JIRA](https://tgs.atlassian.net/browse/PENGSOL-555?atlOrigin=eyJpIjoiYmZkOGZjYjkwYzYxNDEzM2FkZmI2YTQ1OWM2MTIyOTMiLCJwIjoiaiJ9)
[Trello](https://trello.com/c/8EwQjCeA/2084-fix-open-transaction-issue-in-measurement-and-forecast-api)

Update the version of pyPrediktorUtilities to 0.4.5.