### PR TITLE
PENGSOL-587-upgrade-the-version-of-pyprediktor-utilities

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ install_requires =
     pydantic >= 2.0, < 3.0.0
     pandas >= 1.4.4, < 3.0.0
     pyodbc < 6.0.0
-    pyPrediktorUtilities == 0.4.5
+    pyPrediktorUtilities == 0.4.8
 
 [options.packages.find]
 where = src
@@ -72,7 +72,7 @@ testing =
     pytest < 9.0.0
     pytest-cov < 6.0.0
     nest_asyncio < 2.0.0
-    pyPrediktorUtilities == 0.4.5
+    pyPrediktorUtilities == 0.4.8
     pyodbc < 6.0.0
 
 [options.entry_points]


### PR DESCRIPTION
[JIRA](https://tgs.atlassian.net/browse/PENGSOL-587)
[Trello](https://trello.com/c/c7iFDyDd/2142-maf-cron-job-is-not-working-after-upgrade)

Upgrade the version of pyPrediktorUtilities